### PR TITLE
Лишние запросы в БД при экспорте пользователей

### DIFF
--- a/api/Users.php
+++ b/api/Users.php
@@ -52,7 +52,7 @@ class Users extends Simpla
             $group_id_filter = $this->db->placehold('AND u.group_id IN( ?@ )', (array)$filter['group_id']);
         }
 
-        if (isset($filter['keyword'])) {
+        if (isset($filter['keyword']) AND !empty($filter['keyword'])) {
             $keywords = explode(' ', $filter['keyword']);
             foreach ($keywords as $keyword) {
                 $kw = $this->db->escape(trim($keyword));
@@ -112,7 +112,7 @@ class Users extends Simpla
             $group_id_filter = $this->db->placehold('AND u.group_id IN( ?@ )', (array)$filter['group_id']);
         }
 
-        if (isset($filter['keyword'])) {
+        if (isset($filter['keyword']) AND !empty($filter['keyword'])) {
             $keywords = explode(' ', $filter['keyword']);
             foreach ($keywords as $keyword) {
                 $kw = $this->db->escape(trim($keyword));


### PR DESCRIPTION
При экспорте пользователей возникают лишние запросы в keyword

SELECT count(*) as count 
FROM s_users u 
LEFT JOIN s_groups g ON u.group_id=g.id 
WHERE 1 
AND u.name LIKE "%%" OR u.email LIKE "%%"