### PR TITLE
autocomplete triggerSelectOnValidInput

### DIFF
--- a/design/default/html/index.tpl
+++ b/design/default/html/index.tpl
@@ -84,6 +84,7 @@
 			serviceUrl:'ajax/search_products.php',
 			minChars:1,
 			noCache: false,
+			triggerSelectOnValidInput: 0,
 			onSelect:
 				function(suggestion){
 					 $(".input_search").closest('form').submit();


### PR DESCRIPTION
Свойство исключает автоматическое срабатывание
и отправку формы при полном совпадении.
Например есть "Телефон" и "Телефон Nokia 2203",
если я захочу найти "Телефон Nokia", то мне это не удастся в стандартном варианте,
автоматически будет отправляться форма, и с этой страницы уже нельзя будет начать нового поиска.

Ужасно назойливая штука, почему то нет в документации по autocomplete.