### PR TITLE
payment_detail

### DIFF
--- a/api/Orders.php
+++ b/api/Orders.php
@@ -47,6 +47,7 @@ class Orders extends Simpla
                                               o.comment, 
                                               o.status,
                                               o.url, 
+                                              o.payment_details,
                                               o.total_price, 
                                               o.note, 
 										      o.ip
@@ -135,7 +136,7 @@ class Orders extends Simpla
                                               o.email, 
                                               o.comment, 
                                               o.status,
-                                              o.url, 
+                                              o.url,
                                               o.total_price, 
                                               o.note
                                         FROM __orders AS o


### PR DESCRIPTION
Поле есть, но не используется.
Вдруг кому понадобится для хранения в нем каких-то данных для оплаты.
Я использую в модуле сбербанка, т.к. поле не подтягивается через orders->get_order($order_id), приходится доп. запросом получать это поле...